### PR TITLE
Update Jenkinsfile to use pnpm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,9 +32,12 @@ pipeline {
           echo "🛠 Updating apt and installing build tools"
           apt-get update -y
           DEBIAN_FRONTEND=noninteractive apt-get install -y python3 make g++
-          
+
+          echo "📦 Installing pnpm"
+          npm install -g pnpm@10.6.1
+
           echo "📦 Installing node modules"
-          npm ci --legacy-peer-deps
+          pnpm install --frozen-lockfile
         '''
       }
     }
@@ -42,7 +45,7 @@ pipeline {
 
     stage('Build Project') {
       steps {
-        sh 'npm run build'
+        sh 'pnpm run build'
       }
     }
 


### PR DESCRIPTION
## Summary
- install pnpm in Jenkins pipeline and use it for dependency installation
- use pnpm for build step

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_b_683d11ddec608330b8d1191703256686