### PR TITLE
Fix apt-get permission issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,8 +30,8 @@ pipeline {
         sh '''
           set -eux
           echo "🛠 Updating apt and installing build tools"
-          apt-get update -y
-          DEBIAN_FRONTEND=noninteractive apt-get install -y python3 make g++
+          sudo apt-get update -y
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3 make g++
 
           echo "📦 Installing pnpm"
           npm install -g pnpm@10.6.1


### PR DESCRIPTION
## Summary
- use `sudo` for `apt-get` commands in Jenkinsfile

## Testing
- `pre-commit` *(fails: no pre-commit configuration)*

------
https://chatgpt.com/codex/tasks/task_b_683d137293c88330ba2870898a05f565