### PR TITLE
Add Helm chart for AKS deployment

### DIFF
--- a/charts/postiz/Chart.yaml
+++ b/charts/postiz/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: postiz
+version: 0.1.0
+appVersion: "1.0"
+description: Postiz Helm chart for AKS deployment
+keywords:
+  - postiz
+  - social media
+  - marketing
+home: https://postiz.com
+sources:
+  - https://github.com/xtremeverve/postiz
+maintainers:
+  - name: Postiz Maintainers
+    email: dev@postiz.com
+type: application
+dependencies:
+  - name: postgresql
+    version: 16.7.10
+    repository: oci://xtremeverveacr.azurecr.io/helm
+    condition: postgresql.enabled
+  - name: redis
+    version: 21.2.0
+    repository: oci://xtremeverveacr.azurecr.io/helm
+    condition: redis.enabled

--- a/charts/postiz/README.md
+++ b/charts/postiz/README.md
@@ -1,0 +1,12 @@
+# Postiz Helm Chart
+
+This chart deploys the Postiz application along with optional PostgreSQL and Redis dependencies. It is optimized for running on AKS but is compatible with any Kubernetes cluster.
+
+## Installing the Chart
+
+```bash
+helm dependency build charts/postiz
+helm install postiz charts/postiz -n postiz --create-namespace
+```
+
+Customize deployments via `values.yaml`.

--- a/charts/postiz/templates/_helpers.tpl
+++ b/charts/postiz/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{- define "postiz.labels" -}}
+helm.sh/chart: {{ include "postiz.chart" . }}
+{{ include "postiz.selectorLabels" . }}
+{{- end -}}
+
+{{- define "postiz.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "postiz.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "postiz.name" -}}
+{{ .Chart.Name }}
+{{- end -}}
+
+{{- define "postiz.chart" -}}
+{{ printf "%s-%s" .Chart.Name .Chart.Version }}
+{{- end -}}

--- a/charts/postiz/templates/deployment.yaml
+++ b/charts/postiz/templates/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "postiz.name" . }}
+  labels:
+    {{- include "postiz.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "postiz.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "postiz.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: postiz
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $val }}"
+            {{- end }}
+          ports:
+            - containerPort: 3000
+          resources: {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/postiz/templates/hpa.yaml
+++ b/charts/postiz/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "postiz.name" . }}
+  labels:
+    {{- include "postiz.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "postiz.name" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/charts/postiz/templates/ingress.yaml
+++ b/charts/postiz/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "postiz.name" . }}
+  labels:
+    {{- include "postiz.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $val := .Values.ingress.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "postiz.name" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/postiz/templates/service.yaml
+++ b/charts/postiz/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postiz.name" . }}
+  labels:
+    {{- include "postiz.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "postiz.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 3000
+      protocol: TCP
+      name: http

--- a/charts/postiz/values.yaml
+++ b/charts/postiz/values.yaml
@@ -1,0 +1,126 @@
+replicaCount: 1
+
+image:
+  repository: oci://xtremeverveacr.azurecr.io/postiz
+  tag: origin-main-16-20250608-0153
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: postiz.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+hpa:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+postgresql:
+  enabled: true
+  auth:
+    username: postiz
+    password: postiz
+    database: postiz
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi
+
+redis:
+  enabled: true
+  architecture: standalone
+  master:
+    persistence:
+      enabled: true
+      size: 8Gi
+  auth:
+    enabled: false
+
+env:
+  DATABASE_URL: ""
+  REDIS_URL: ""
+  JWT_SECRET: ""
+  FRONTEND_URL: ""
+  NEXT_PUBLIC_BACKEND_URL: ""
+  BACKEND_INTERNAL_URL: ""
+  CLOUDFLARE_ACCOUNT_ID: ""
+  CLOUDFLARE_ACCESS_KEY: ""
+  CLOUDFLARE_SECRET_ACCESS_KEY: ""
+  CLOUDFLARE_BUCKETNAME: ""
+  CLOUDFLARE_BUCKET_URL: ""
+  CLOUDFLARE_REGION: "auto"
+  STORAGE_PROVIDER: "local"
+  X_API_KEY: ""
+  X_API_SECRET: ""
+  LINKEDIN_CLIENT_ID: ""
+  LINKEDIN_CLIENT_SECRET: ""
+  REDDIT_CLIENT_ID: ""
+  REDDIT_CLIENT_SECRET: ""
+  GITHUB_CLIENT_ID: ""
+  GITHUB_CLIENT_SECRET: ""
+  BEEHIIVE_API_KEY: ""
+  BEEHIIVE_PUBLICATION_ID: ""
+  THREADS_APP_ID: ""
+  THREADS_APP_SECRET: ""
+  FACEBOOK_APP_ID: ""
+  FACEBOOK_APP_SECRET: ""
+  YOUTUBE_CLIENT_ID: ""
+  YOUTUBE_CLIENT_SECRET: ""
+  TIKTOK_CLIENT_ID: ""
+  TIKTOK_CLIENT_SECRET: ""
+  PINTEREST_CLIENT_ID: ""
+  PINTEREST_CLIENT_SECRET: ""
+  DRIBBBLE_CLIENT_ID: ""
+  DRIBBBLE_CLIENT_SECRET: ""
+  DISCORD_CLIENT_ID: ""
+  DISCORD_CLIENT_SECRET: ""
+  DISCORD_BOT_TOKEN_ID: ""
+  SLACK_ID: ""
+  SLACK_SECRET: ""
+  SLACK_SIGNING_SECRET: ""
+  MASTODON_URL: "https://mastodon.social"
+  MASTODON_CLIENT_ID: ""
+  MASTODON_CLIENT_SECRET: ""
+  OPENAI_API_KEY: ""
+  NEXT_PUBLIC_DISCORD_SUPPORT: ""
+  NEXT_PUBLIC_POLOTNO: ""
+  API_LIMIT: 30
+  FEE_AMOUNT: 0.05
+  STRIPE_PUBLISHABLE_KEY: ""
+  STRIPE_SECRET_KEY: ""
+  STRIPE_SIGNING_KEY: ""
+  STRIPE_SIGNING_KEY_CONNECT: ""
+  NX_ADD_PLUGINS: false
+  IS_GENERAL: "true"
+  NEXT_PUBLIC_POSTIZ_OAUTH_DISPLAY_NAME: "Authentik"
+  NEXT_PUBLIC_POSTIZ_OAUTH_LOGO_URL: "https://raw.githubusercontent.com/walkxcode/dashboard-icons/master/png/authentik.png"
+  POSTIZ_GENERIC_OAUTH: "false"
+  POSTIZ_OAUTH_URL: "https://auth.example.com"
+  POSTIZ_OAUTH_AUTH_URL: "https://auth.example.com/application/o/authorize"
+  POSTIZ_OAUTH_TOKEN_URL: "https://auth.example.com/application/o/token"
+  POSTIZ_OAUTH_USERINFO_URL: "https://authentik.example.com/application/o/userinfo"
+  POSTIZ_OAUTH_CLIENT_ID: ""
+  POSTIZ_OAUTH_CLIENT_SECRET: ""
+  DUB_TOKEN: ""
+  DUB_API_ENDPOINT: ""
+  DUB_SHORT_LINK_DOMAIN: ""


### PR DESCRIPTION
## Summary
- add production-grade Helm chart under `charts/postiz`
- include PostgreSQL and Redis dependencies from ACR
- expose configurable env vars, HPA and resources via `values.yaml`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68464cf962d08330aac630d3e1928e11