### PR TITLE
Configure ingress for production host

### DIFF
--- a/charts/postiz/values.yaml
+++ b/charts/postiz/values.yaml
@@ -10,15 +10,19 @@ service:
   port: 80
 
 ingress:
-  enabled: false
-  className: ""
-  annotations: {}
+  enabled: true
+  className: "nginx"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt"
   hosts:
-    - host: postiz.local
+    - host: social-scheduler.xtremeverve.com
       paths:
         - path: /
           pathType: Prefix
-  tls: []
+  tls:
+    - hosts:
+        - social-scheduler.xtremeverve.com
+      secretName: social-scheduler-tls
 
 resources:
   limits:


### PR DESCRIPTION
## Summary
- enable nginx ingress in Helm values
- configure cert-manager annotations for TLS
- set domain to `social-scheduler.xtremeverve.com`

## Testing
- `pnpm test --run` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_b_6846500234dc8330ab179a01080a7e4f