### PR TITLE
Fix local docker build for AKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@
 
 To have the project up and running, please follow the [Quick Start Guide](https://docs.postiz.com/quickstart)
 
+### Building Docker Images
+
+If you build the Docker image on a machine with a different CPU architecture than your AKS nodes, the container may fail to start with an `exec format error`. Build with Docker Buildx and specify the target platform:
+
+```bash
+docker buildx create --use          # run once to initialize buildx
+docker buildx build --platform linux/amd64 \
+  -f Dockerfile.dev \
+  -t <registry>/<image>:<tag> \
+  --push .
+```
+
+Add `linux/arm64` to `--platform` if your cluster uses ARM64 nodes. Buildx will produce a multi-architecture image compatible with both AKS and your local machine.
+
 ## Invest in the Postiz Coin :)
 
 DMsTbeCfX1crgAse5tver98KAMarPWeP3d6U3Gmmpump

--- a/var/docker/docker-build.sh
+++ b/var/docker/docker-build.sh
@@ -2,6 +2,12 @@
 
 set -o xtrace
 
+# Target platform for the image. Defaults to linux/amd64 which works on most AKS nodes.
+PLATFORM="${PLATFORM:-linux/amd64}"
+
+# Ensure buildx is initialized
+docker buildx inspect >/dev/null 2>&1 || docker buildx create --use
+
 docker rmi localhost/postiz || true
-docker build --target dist -t localhost/postiz -f Dockerfile.dev .
-docker build --target devcontainer -t localhost/postiz-devcontainer -f Dockerfile.dev .
+docker buildx build --platform "$PLATFORM" --target dist -t localhost/postiz -f Dockerfile.dev .
+docker buildx build --platform "$PLATFORM" --target devcontainer -t localhost/postiz-devcontainer -f Dockerfile.dev .


### PR DESCRIPTION
## Summary
- document how to build for multiple architectures
- build local images with buildx so the result works on AKS

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.6.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_68465fd71b7c8330aa323b981d90288e